### PR TITLE
fix(config): miss config def from openai to open_ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ All configuration variables are optional with defaults. All CLI options will def
     theme = "",
     theme_file = "",
     ollama_url = "",
-    openai_url = "",
-    openai_token = "",
+    open_ai_url = "",
+    open_ai_token = "",
 }
 ```
 

--- a/lua/oatmeal/init.lua
+++ b/lua/oatmeal/init.lua
@@ -110,8 +110,8 @@ function M.start()
     "editor",
     "model",
     "ollama-url",
-    "openai-token",
-    "openai-url",
+    "open-ai-token",
+    "open-ai-url",
     "theme",
     "theme-file",
   }


### PR DESCRIPTION
## Background

I got this error when run Oatmeal using `openai`
```shell
error: unexpected argument '--openai-url' found
```
it same with arg openai-token.

But Oatmeal CLI expect args like this
```shell
oatmeal --editor <editor> --backend <backend> --model <model> --open-ai-url <open-ai-url> --open-ai-token <open-ai-token>
```
## Finding
Flags defined as `openai_url` and `openai_token` and parsed to args `openai-url` and `openai-token`.
### Expectation
Oatmeal args:
- `open-ai-url`
- `open-ai-token`

## Solution

So, this PR came with some changes:
* Redefine config `openai_url` to `open_ai_url`
* Redefine config `openai_token` to `open_ai_token` 

It's works well on my machine

<img width="537" alt="image" src="https://github.com/dustinblackman/oatmeal.nvim/assets/13098072/cb38cade-86cf-4bb7-bac3-c815363918ae">
